### PR TITLE
Add auth dependency and secure track/playlist actions

### DIFF
--- a/dependencies.py
+++ b/dependencies.py
@@ -1,0 +1,29 @@
+from fastapi import Depends, HTTPException
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from sqlalchemy.orm import Session
+
+from db.database import SessionLocal
+from models.models import User
+
+security = HTTPBearer()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+    db: Session = Depends(get_db),
+):
+    token = credentials.credentials
+    if not token.isdigit():
+        raise HTTPException(status_code=401, detail="Invalid token")
+    user = db.query(User).filter(User.id == int(token)).first()
+    if not user:
+        raise HTTPException(status_code=401, detail="Invalid user")
+    return user

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from routers.track import router as track_router
+from routers.playlist import router as playlist_router
 from fastapi.templating import Jinja2Templates
 from fastapi.responses import HTMLResponse
 from fastapi import Request
@@ -9,6 +10,7 @@ from db.database import Base, engine
 app = FastAPI()
 app.mount("/static", StaticFiles(directory="static"), name="static")
 app.include_router(track_router)
+app.include_router(playlist_router)
 
 templates = Jinja2Templates(directory="templates")
 

--- a/routers/playlist.py
+++ b/routers/playlist.py
@@ -1,0 +1,55 @@
+from fastapi import APIRouter, Depends, Form, HTTPException
+from sqlalchemy.orm import Session
+
+from models.models import Playlist, User
+from dependencies import get_current_user, get_db
+from schemas.schemas import PlaylistOut
+
+router = APIRouter(prefix="/playlists", tags=["Playlists"])
+
+
+@router.post("/add", response_model=PlaylistOut)
+def create_playlist(
+    name: str = Form(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    playlist = Playlist(name=name, user_id=current_user.id)
+    db.add(playlist)
+    db.commit()
+    db.refresh(playlist)
+    return playlist
+
+
+@router.put("/update/{id}", response_model=PlaylistOut)
+def update_playlist(
+    id: int,
+    name: str = Form(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    playlist = db.query(Playlist).filter(Playlist.id == id).first()
+    if not playlist:
+        raise HTTPException(status_code=404, detail="Плейлист не знайдено")
+    if playlist.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Недостатньо прав")
+    playlist.name = name
+    db.commit()
+    db.refresh(playlist)
+    return playlist
+
+
+@router.delete("/delete/{id}")
+def delete_playlist(
+    id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    playlist = db.query(Playlist).filter(Playlist.id == id).first()
+    if not playlist:
+        raise HTTPException(status_code=404, detail="Плейлист не знайдено")
+    if playlist.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Недостатньо прав")
+    db.delete(playlist)
+    db.commit()
+    return {"message": "Плейлист видалено"}

--- a/routers/track.py
+++ b/routers/track.py
@@ -1,8 +1,8 @@
 import os
 from fastapi import APIRouter, Depends, UploadFile, File, Form, HTTPException
 from sqlalchemy.orm import Session
-from db.database import SessionLocal
-from models.models import Track
+from models.models import Track, User
+from dependencies import get_current_user, get_db
 from schemas.schemas import TrackCreate, TrackOut
 from fastapi.responses import FileResponse
 
@@ -11,44 +11,58 @@ os.makedirs(UPLOAD_DIR, exist_ok=True)
 
 router = APIRouter(prefix="/tracks", tags=["Tracks"])
 
-def get_db():
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
-
 @router.get("/", response_model=list[TrackOut])
 def get_all_tracks(db: Session = Depends(get_db)):
     return db.query(Track).all()
 
 @router.post("/add", response_model=TrackOut)
-async def upload_track(file: UploadFile = File(...), db: Session = Depends(get_db)):
+async def upload_track(
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     track = TrackCreate(name=file.filename)
     filepath = os.path.join(UPLOAD_DIR, file.filename)
     with open(filepath, "wb") as buffer:
         buffer.write(await file.read())
-    db_track = Track(title=file.filename, filename=file.filename, author_id=1)  # тимчасово
+    db_track = Track(
+        title=file.filename,
+        filename=file.filename,
+        author_id=current_user.id,
+    )
     db.add(db_track)
     db.commit()
     db.refresh(db_track)
     return db_track
 
 @router.put("/update/{id}", response_model=TrackOut)
-def update_track(id: int, title: str = Form(...), db: Session = Depends(get_db)):
+def update_track(
+    id: int,
+    title: str = Form(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     track = db.query(Track).filter(Track.id == id).first()
     if not track:
         raise HTTPException(status_code=404, detail="Трек не знайдено")
+    if track.author_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Недостатньо прав")
     track.title = title
     db.commit()
     db.refresh(track)
     return track
 
 @router.delete("/delete/{id}")
-def delete_track(id: int, db: Session = Depends(get_db)):
+def delete_track(
+    id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
     track = db.query(Track).filter(Track.id == id).first()
     if not track:
         raise HTTPException(status_code=404, detail="Трек не знайдено")
+    if track.author_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Недостатньо прав")
     db.delete(track)
     db.commit()
     filepath = os.path.join(UPLOAD_DIR, track.filename)
@@ -69,8 +83,3 @@ def play_track(id: int, db: Session = Depends(get_db)):
 @router.get("/search", response_model=list[TrackOut])
 def search_tracks(query: str, db: Session = Depends(get_db)):
     return db.query(Track).filter(Track.title.ilike(f"%{query}%")).all()
-
-
-from turtle import *
-
-color("red")

--- a/schemas/schemas.py
+++ b/schemas/schemas.py
@@ -21,3 +21,15 @@ class TrackOut(TrackBase):
 
     class Config:
         orm_mode = True
+
+
+class PlaylistBase(BaseModel):
+    name: str
+
+
+class PlaylistOut(PlaylistBase):
+    id: int
+    user_id: int
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
## Summary
- add dependency for extracting current user
- secure track upload/update/delete endpoints
- introduce playlist endpoints with same protection
- wire up playlist router
- expose playlist schema models

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871448d4c848325af802faef8138f83